### PR TITLE
Add default seed data for roles, statuses and service categories

### DIFF
--- a/HouseholdServices.Infrastructure/Data/Configurations/OrderStatusConfiguration.cs
+++ b/HouseholdServices.Infrastructure/Data/Configurations/OrderStatusConfiguration.cs
@@ -21,5 +21,11 @@ public class OrderStatusConfiguration: IEntityTypeConfiguration<OrderStatus>
         
         builder.HasIndex(order => order.Name)
             .IsUnique();
+
+        builder.HasData(
+            new OrderStatus { OrderStatusId = 1, Name = "created" },
+            new OrderStatus { OrderStatusId = 2, Name = "in_progress" },
+            new OrderStatus { OrderStatusId = 3, Name = "completed" },
+            new OrderStatus { OrderStatusId = 4, Name = "cancelled" });
     }
 }

--- a/HouseholdServices.Infrastructure/Data/Configurations/RequestStatusConfiguration.cs
+++ b/HouseholdServices.Infrastructure/Data/Configurations/RequestStatusConfiguration.cs
@@ -21,5 +21,11 @@ public class RequestStatusConfiguration: IEntityTypeConfiguration<RequestStatus>
         
         builder.HasIndex(request => request.Name)
             .IsUnique();
+
+        builder.HasData(
+            new RequestStatus { RequestStatusId = 1, Name = "open" },
+            new RequestStatus { RequestStatusId = 2, Name = "in_progress" },
+            new RequestStatus { RequestStatusId = 3, Name = "completed" },
+            new RequestStatus { RequestStatusId = 4, Name = "cancelled" });
     }
 }

--- a/HouseholdServices.Infrastructure/Data/Configurations/ResponseStatusConfiguration.cs
+++ b/HouseholdServices.Infrastructure/Data/Configurations/ResponseStatusConfiguration.cs
@@ -21,5 +21,10 @@ public class ResponseStatusConfiguration: IEntityTypeConfiguration<ResponseStatu
         
         builder.HasIndex(response => response.Name)
             .IsUnique();
+
+        builder.HasData(
+            new ResponseStatus { ResponseStatusId = 1, Name = "pending" },
+            new ResponseStatus { ResponseStatusId = 2, Name = "accepted" },
+            new ResponseStatus { ResponseStatusId = 3, Name = "rejected" });
     }
 }

--- a/HouseholdServices.Infrastructure/Data/Configurations/RoleConfiguration.cs
+++ b/HouseholdServices.Infrastructure/Data/Configurations/RoleConfiguration.cs
@@ -22,5 +22,9 @@ public class RoleConfiguration: IEntityTypeConfiguration<Role>
         
         builder.HasIndex(role => role.Name)
             .IsUnique();
+
+        builder.HasData(
+            new Role { RoleId = 1, Name = "client" },
+            new Role { RoleId = 2, Name = "master" });
     }
 }

--- a/HouseholdServices.Infrastructure/Data/Configurations/ServiceCategoryConfiguration.cs
+++ b/HouseholdServices.Infrastructure/Data/Configurations/ServiceCategoryConfiguration.cs
@@ -25,5 +25,37 @@ public class ServiceCategoryConfiguration: IEntityTypeConfiguration<ServiceCateg
         
         builder.HasIndex(category => category.Name)
             .IsUnique();
+
+        builder.HasData(
+            new ServiceCategory
+            {
+                CategoryId = 1,
+                Name = "plumbing",
+                Description = "Plumbing installation, repairs, and maintenance."
+            },
+            new ServiceCategory
+            {
+                CategoryId = 2,
+                Name = "electrical",
+                Description = "Electrical installation, diagnostics, and repairs."
+            },
+            new ServiceCategory
+            {
+                CategoryId = 3,
+                Name = "cleaning",
+                Description = "Regular, deep, and post-renovation cleaning."
+            },
+            new ServiceCategory
+            {
+                CategoryId = 4,
+                Name = "appliance_repair",
+                Description = "Diagnostics and repair of household appliances."
+            },
+            new ServiceCategory
+            {
+                CategoryId = 5,
+                Name = "furniture_assembly",
+                Description = "Furniture assembly, installation, and minor repairs."
+            });
     }
 }

--- a/HouseholdServices.Infrastructure/Migrations/20260513122529_SeedLookupData.Designer.cs
+++ b/HouseholdServices.Infrastructure/Migrations/20260513122529_SeedLookupData.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HouseholdServices.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HouseholdServices.Infrastructure.Migrations
 {
     [DbContext(typeof(HouseholdServicesDbContext))]
-    partial class HouseholdServicesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260513122529_SeedLookupData")]
+    partial class SeedLookupData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HouseholdServices.Infrastructure/Migrations/20260513122529_SeedLookupData.cs
+++ b/HouseholdServices.Infrastructure/Migrations/20260513122529_SeedLookupData.cs
@@ -1,0 +1,163 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace HouseholdServices.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedLookupData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "order_statuses",
+                columns: new[] { "order_status_id", "name" },
+                values: new object[,]
+                {
+                    { 1, "created" },
+                    { 2, "in_progress" },
+                    { 3, "completed" },
+                    { 4, "cancelled" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "request_statuses",
+                columns: new[] { "request_status_id", "name" },
+                values: new object[,]
+                {
+                    { 1, "open" },
+                    { 2, "in_progress" },
+                    { 3, "completed" },
+                    { 4, "cancelled" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "response_statuses",
+                columns: new[] { "response_status_id", "name" },
+                values: new object[,]
+                {
+                    { 1, "pending" },
+                    { 2, "accepted" },
+                    { 3, "rejected" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "roles",
+                columns: new[] { "role_id", "name" },
+                values: new object[,]
+                {
+                    { 1, "client" },
+                    { 2, "master" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "service_categories",
+                columns: new[] { "category_id", "description", "name" },
+                values: new object[,]
+                {
+                    { 1, "Plumbing installation, repairs, and maintenance.", "plumbing" },
+                    { 2, "Electrical installation, diagnostics, and repairs.", "electrical" },
+                    { 3, "Regular, deep, and post-renovation cleaning.", "cleaning" },
+                    { 4, "Diagnostics and repair of household appliances.", "appliance_repair" },
+                    { 5, "Furniture assembly, installation, and minor repairs.", "furniture_assembly" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "order_statuses",
+                keyColumn: "order_status_id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "order_statuses",
+                keyColumn: "order_status_id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "order_statuses",
+                keyColumn: "order_status_id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "order_statuses",
+                keyColumn: "order_status_id",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "request_statuses",
+                keyColumn: "request_status_id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "request_statuses",
+                keyColumn: "request_status_id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "request_statuses",
+                keyColumn: "request_status_id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "request_statuses",
+                keyColumn: "request_status_id",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "response_statuses",
+                keyColumn: "response_status_id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "response_statuses",
+                keyColumn: "response_status_id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "response_statuses",
+                keyColumn: "response_status_id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "roles",
+                keyColumn: "role_id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "roles",
+                keyColumn: "role_id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "service_categories",
+                keyColumn: "category_id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "service_categories",
+                keyColumn: "category_id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "service_categories",
+                keyColumn: "category_id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "service_categories",
+                keyColumn: "category_id",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "service_categories",
+                keyColumn: "category_id",
+                keyValue: 5);
+        }
+    }
+}


### PR DESCRIPTION
Added default seed data for base reference entities:

- `Role`
- `RequestStatus`
- `ResponseStatus`
- `OrderStatus`
- `ServiceCategory`

## Details

- Defined initial values for the required reference tables.
- Added default data using `HasData()` in the EF Core configuration.
- Created a new migration for inserting the seed data.
- Applied the migration to the PostgreSQL database.
- Verified that the default records were successfully added to the corresponding tables.