### PR TITLE
Интегрировать PaymentService в оплату заказов

### DIFF
--- a/HouseholdServices.API/Controllers/OrdersController.cs
+++ b/HouseholdServices.API/Controllers/OrdersController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using HouseholdServices.Application.DTOs.Order;
+using HouseholdServices.Application.DTOs.Payment;
 using HouseholdServices.Application.Exceptions.Order;
 using HouseholdServices.Application.Services.Order;
 using Microsoft.AspNetCore.Authorization;
@@ -74,6 +75,34 @@ public class OrdersController : ControllerBase
         await _orderService.UpdateInitialMeetingAsync(orderId, request);
 
         return NoContent();
+    }
+
+    [HttpPost("{orderId:int}/pay")]
+    public async Task<ActionResult<PaymentStatusResponse>> PayOrder(
+        int orderId,
+        PayOrderRequest request)
+    {
+        try
+        {
+            PaymentStatusResponse response = await _orderService.PayAsync(orderId, request);
+
+            if (response.IsPaid)
+                return Ok(response);
+
+            return BadRequest(response);
+        }
+        catch (OrderNotFoundException exception)
+        {
+            return StatusCode(StatusCodes.Status404NotFound, exception.Message);
+        }
+        catch (OrderAccessDeniedException exception)
+        {
+            return StatusCode(StatusCodes.Status403Forbidden, exception.Message);
+        }
+        catch (OrderCannotBePaidException exception)
+        {
+            return Conflict(exception.Message);
+        }
     }
 
     [HttpPatch("{orderId:int}/complete")]

--- a/HouseholdServices.Application/DTOs/Order/PayOrderRequest.cs
+++ b/HouseholdServices.Application/DTOs/Order/PayOrderRequest.cs
@@ -1,0 +1,6 @@
+namespace HouseholdServices.Application.DTOs.Order;
+
+public class PayOrderRequest
+{
+    public string CardNumber { get; set; } = null!;
+}

--- a/HouseholdServices.Application/Exceptions/Order/OrderCannotBePaidException.cs
+++ b/HouseholdServices.Application/Exceptions/Order/OrderCannotBePaidException.cs
@@ -1,0 +1,9 @@
+namespace HouseholdServices.Application.Exceptions.Order;
+
+public class OrderCannotBePaidException : Exception
+{
+    public OrderCannotBePaidException()
+        : base("This order cannot be paid.")
+    {
+    }
+}

--- a/HouseholdServices.Application/Services/Order/IOrderService.cs
+++ b/HouseholdServices.Application/Services/Order/IOrderService.cs
@@ -1,4 +1,5 @@
 using HouseholdServices.Application.DTOs.Order;
+using HouseholdServices.Application.DTOs.Payment;
 
 namespace HouseholdServices.Application.Services.Order;
 
@@ -8,6 +9,7 @@ public interface IOrderService
     Task<IReadOnlyCollection<UserOrderListItemResponse>> GetCurrentClientOrdersAsync();
     Task<IReadOnlyCollection<MasterOrderListItemResponse>> GetCurrentMasterOrdersAsync();
     Task UpdateInitialMeetingAsync(int orderId, UpdateOrderInitialMeetingRequest request);
+    Task<PaymentStatusResponse> PayAsync(int orderId, PayOrderRequest request);
     Task CompleteAsync(int orderId);
     Task CancelAsync(int orderId);
 }

--- a/HouseholdServices.Infrastructure/Services/Orders/OrderService.cs
+++ b/HouseholdServices.Infrastructure/Services/Orders/OrderService.cs
@@ -1,6 +1,8 @@
 using HouseholdServices.Application.Services.Order;
 using HouseholdServices.Application.DTOs.Order;
+using HouseholdServices.Application.DTOs.Payment;
 using HouseholdServices.Application.Services.Users;
+using HouseholdServices.Application.Services.Payment;
 using HouseholdServices.Domain.Entities;
 using HouseholdServices.Infrastructure.Data;
 using HouseholdServices.Application.Exceptions.Order;
@@ -12,11 +14,16 @@ public class OrderService : IOrderService
 {
     private readonly HouseholdServicesDbContext _dbContext;
     private readonly ICurrentUserService _currentUserService;
+    private readonly IPaymentClient _paymentClient;
 
-    public OrderService(HouseholdServicesDbContext dbContext, ICurrentUserService currentUserService)
+    public OrderService(
+        HouseholdServicesDbContext dbContext,
+        ICurrentUserService currentUserService,
+        IPaymentClient paymentClient)
     {
         _dbContext = dbContext;
         _currentUserService = currentUserService;
+        _paymentClient = paymentClient;
     }
 
     public async Task<OrderResponse> GetByIdAsync(int orderId)
@@ -155,6 +162,39 @@ public class OrderService : IOrderService
         order.InitialMeetingAt = request.InitialMeetingAt;
 
         await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task<PaymentStatusResponse> PayAsync(int orderId, PayOrderRequest request)
+    {
+        Order? order = await _dbContext.Orders
+            .Include(order => order.Response)
+            .ThenInclude(response => response.Request)
+            .FirstOrDefaultAsync(order => order.OrderId == orderId);
+
+        if (order == null)
+            throw new OrderNotFoundException();
+
+        int currentUserId = _currentUserService.GetUserId();
+        string currentUserRole = _currentUserService.GetRole();
+
+        if (currentUserRole != "client" || order.Response.Request.ClientId != currentUserId)
+        {
+            throw new OrderAccessDeniedException();
+        }
+
+        if (order.OrderStatusId != 1)
+        {
+            throw new OrderCannotBePaidException();
+        }
+
+        CreatePaymentRequest paymentRequest = new CreatePaymentRequest
+        {
+            OrderId = order.OrderId,
+            Amount = order.Price,
+            CardNumber = request.CardNumber
+        };
+
+        return await _paymentClient.PayAsync(paymentRequest);
     }
 
     public async Task CompleteAsync(int orderId)

--- a/HouseholdServices.Infrastructure/Services/Payment/PaymentClient.cs
+++ b/HouseholdServices.Infrastructure/Services/Payment/PaymentClient.cs
@@ -16,11 +16,13 @@ public class PaymentClient : IPaymentClient
     public async Task<PaymentStatusResponse> PayAsync(CreatePaymentRequest request)
     {
         HttpResponseMessage response = await _httpClient.PostAsJsonAsync("api/payment/pay", request);
-        response.EnsureSuccessStatusCode();
 
         PaymentStatusResponse? result = await response.Content.ReadFromJsonAsync<PaymentStatusResponse>();
         if (result is null)
+        {
+            response.EnsureSuccessStatusCode();
             throw new InvalidOperationException("Payment service returned empty response");
+        }
 
         return result;
     }


### PR DESCRIPTION
## Что сделано
- Добавлен endpoint `POST /api/orders/{orderId}/pay` для оплаты заказа
- Основной бэкенд теперь вызывает моковый PaymentService из бизнес-флоу заказов
- Оплата доступна только клиенту, которому принадлежит заказ
- Для оплаты используется сумма из `Order.Price`
- Добавлена проверка, что оплатить можно только заказ в статусе `in_progress`
- Обработка отказа платежа возвращает ответ мокового PaymentService клиенту
